### PR TITLE
Update 3: Run SonarCloud only on pull requests to master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ steps:
     projects: '**/*.csproj'
 
 - task: SonarCloudPrepare@1
-  displayName: 'Prepare SonarCloud analysis'
+  displayName: 'Prepare SonarCloud analysis - again'
   inputs:
     SonarCloud: 'SonarCloud connection 1'
     organization: '$(SonarOrganization)'


### PR DESCRIPTION
Run SonarCloud less often to reduce build times for normal CI builds.